### PR TITLE
feat: Bare-minimum generator update to support 1.19.4

### DIFF
--- a/generator/src/main/java/net/kyori/adventure/data/generator/GameDataGenerator.java
+++ b/generator/src/main/java/net/kyori/adventure/data/generator/GameDataGenerator.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.data.generator;
 import java.nio.file.Path;
 import java.util.List;
 import net.minecraft.SharedConstants;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.BlockItem;
@@ -48,7 +48,9 @@ public final class GameDataGenerator {
    * @param args arguments, expected to be {@code <output directory> }
    */
   public static void main(final String[] args) {
+    SharedConstants.tryDetectVersion();
     Bootstrap.bootStrap();
+    Bootstrap.validate();
     LOGGER.log(System.Logger.Level.INFO, "Generating data for Minecraft version {0}", SharedConstants.getCurrentVersion().getName());
 
     // Create a generator context based on arguments
@@ -59,11 +61,11 @@ public final class GameDataGenerator {
     final var generators = List.of(
       // new TranslationGenerator(), // This creates a 33k-line source file that is a large fraction of the output jar... let's expose different things instead.
       new RegistryEntriesGenerator<>("VanillaBlocks",
-        Registry.BLOCK,
+        Registries.BLOCK,
         "Block types present in <em>Minecraft: Java Edition</em> $L.",
         Block::getDescriptionId),
       new RegistryEntriesGenerator<>("VanillaItems",
-        Registry.ITEM,
+        Registries.ITEM,
         """
           Item types present in <em>Minecraft: Java Edition</em> $L.
           
@@ -74,11 +76,11 @@ public final class GameDataGenerator {
         Item::getDescriptionId,
         it -> !(it instanceof BlockItem)),
       new RegistryEntriesGenerator<>("VanillaEntities",
-        Registry.ENTITY_TYPE,
+        Registries.ENTITY_TYPE,
         "Entity types present in <em>Minecraft: Java Edition</em> $L.",
         EntityType::getDescriptionId),
       new RegistryEntriesGenerator<>("VanillaSounds",
-        Registry.SOUND_EVENT,
+        Registries.SOUND_EVENT,
         "Sound events present in vanilla <em>Minecraft: Java Edition</em> $L.",
         ev -> "subtitles." + ev.getLocation().getPath()),
       new KeybindGenerator()

--- a/generator/src/main/java/net/kyori/adventure/data/generator/RegistryEntriesGenerator.java
+++ b/generator/src/main/java/net/kyori/adventure/data/generator/RegistryEntriesGenerator.java
@@ -31,22 +31,23 @@ import java.util.function.Predicate;
 import javax.lang.model.element.Modifier;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.Registry;
-import net.minecraft.core.WritableRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 
 // Generates a constants file based on registry entries
 class RegistryEntriesGenerator<V> implements Generator {
   private final String className;
   private final String classJd;
-  private final Registry<V> registry;
+  private final ResourceKey<? extends Registry<V>> registry;
   private final Function<V, String> localizationKeyGetter;
   private final Predicate<V> filter;
 
-  RegistryEntriesGenerator(final String className, final Registry<V> registry, final String documentation, final Function<V, String> localizationKeyGetter) {
+  RegistryEntriesGenerator(final String className, final ResourceKey<? extends Registry<V>> registry, final String documentation, final Function<V, String> localizationKeyGetter) {
     this(className, registry, documentation, localizationKeyGetter, v -> true);
   }
 
-  RegistryEntriesGenerator(final String className, final Registry<V> registry, final String documentation, final Function<V, String> localizationKeyGetter, final Predicate<V> filter) {
+  RegistryEntriesGenerator(final String className, final ResourceKey<? extends Registry<V>> registry, final String documentation, final Function<V, String> localizationKeyGetter, final Predicate<V> filter) {
     this.className = className;
     this.classJd = documentation;
     this.registry = registry;
@@ -58,12 +59,7 @@ class RegistryEntriesGenerator<V> implements Generator {
   @SuppressWarnings({"unchecked", "rawtypes"})
   public String name() {
     // This is a bit awkward, but maintains compatibility with pre-1.16 versions
-    final String registryName;
-    if(this.registry instanceof WritableRegistry<?>) {
-      registryName = ((Registry) Registry.REGISTRY).getKey(this.registry).toString();
-    } else {
-      registryName = this.registry.toString();
-    }
+    final String registryName = this.registry.location().toString();
     return "elements of registry " + registryName;
   }
 
@@ -71,17 +67,23 @@ class RegistryEntriesGenerator<V> implements Generator {
   public void generate(final Context ctx) throws IOException {
     final var clazz = Types.utilityClass(this.className, this.classJd, SharedConstants.getCurrentVersion().getName());
 
-    this.registry.stream()
+    final Registry<V> registry = this.registry();
+    registry.stream()
       .filter(this.filter)
-      .sorted(Comparator.comparing(this.registry::getKey))
+      .sorted(Comparator.comparing(registry::getKey))
       .map(this::makeField)
       .forEachOrdered(clazz::addField);
 
     ctx.write(clazz.build());
   }
 
+  @SuppressWarnings("unchecked")
+  private Registry<V> registry() {
+    return BuiltInRegistries.REGISTRY.get((ResourceKey) this.registry);
+  }
+
   private FieldSpec makeField(final V element) {
-    final ResourceLocation id = this.registry.getKey(element);
+    final ResourceLocation id = this.registry().getKey(element);
     final String localizationKey = this.localizationKeyGetter.apply(element);
     return FieldSpec.builder(Types.KEYED_NAMED_HOLDER, Types.keyToFieldName(id.getPath()), Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
       .initializer("new $T($S, $S)", Types.KEYED_NAMED_HOLDER_IMPL, id.toString(), localizationKey)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 dataVersion=1.0.0
-minecraftVersion=1.16.5
+minecraftVersion=1.19.4-rc2
 generatorTarget=17
 
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2G


### PR DESCRIPTION
This is a quick runthrough of what's needed to get the generator working on 1.19.4.

I do not think this is the correct approach, but the diff is here for visibility. imo what we should be doing is having one `generator` codebase that supports all active game versions, which means we can continually update/improve generators and propogate that back to older data versions.

This should also take feature flags into account -- either by putting the experimental features into another class, or by giving them some sort of annotation.